### PR TITLE
Fix gyms persistent data not persisting

### DIFF
--- a/src/main/java/lol/gito/radgyms/mixin/DataSaver.java
+++ b/src/main/java/lol/gito/radgyms/mixin/DataSaver.java
@@ -44,6 +44,11 @@ public abstract class DataSaver implements EntityDataSaver {
         return gymsPersistentData;
     }
 
+    @Unique
+    public void setGymsPersistentData(NbtCompound gymsPersistentData) {
+        this.gymsPersistentData = gymsPersistentData;
+    }
+
     @Inject(method = "writeNbt", at = @At("HEAD"))
     protected void RadGyms$injectWriteMethod(NbtCompound nbt, CallbackInfoReturnable<NbtCompound> cir) {
         if (gymsPersistentData != null) {

--- a/src/main/java/lol/gito/radgyms/mixin/OnServerPlayerCopy.java
+++ b/src/main/java/lol/gito/radgyms/mixin/OnServerPlayerCopy.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025. gitoido-mc
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * you can obtain one at https://github.com/gitoido-mc/rad-gyms/blob/main/LICENSE.
+ *
+ */
+
+package lol.gito.radgyms.mixin;
+
+import com.mojang.authlib.GameProfile;
+import lol.gito.radgyms.RadGyms;
+import lol.gito.radgyms.nbt.EntityDataSaver;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerPlayerEntity.class)
+public abstract class OnServerPlayerCopy extends PlayerEntity {
+    public OnServerPlayerCopy(World world, BlockPos pos, float yaw, GameProfile gameProfile) {
+        super(world, pos, yaw, gameProfile);
+    }
+
+    @Inject(method = "copyFrom", at = @At("RETURN"))
+    protected void RadGyms$copyFrom(ServerPlayerEntity oldPlayer, boolean alive, CallbackInfo ci) {
+        ((EntityDataSaver)this).setGymsPersistentData(((EntityDataSaver)oldPlayer).getGymsPersistentData());
+        RadGyms.INSTANCE.debug("PersistentData copied for player " + this.getUuid());
+    }
+}

--- a/src/main/kotlin/lol/gito/radgyms/nbt/EntityDataSaver.kt
+++ b/src/main/kotlin/lol/gito/radgyms/nbt/EntityDataSaver.kt
@@ -12,4 +12,5 @@ import net.minecraft.nbt.NbtCompound
 
 interface EntityDataSaver {
     fun getGymsPersistentData(): NbtCompound
+    fun setGymsPersistentData(data: NbtCompound)
 }

--- a/src/main/resources/rad-gyms.mixins.json
+++ b/src/main/resources/rad-gyms.mixins.json
@@ -5,7 +5,8 @@
   "mixins": [
     "AetherEntityInteract",
     "BundleItemMixin",
-    "DataSaver"
+    "DataSaver",
+    "OnServerPlayerCopy"
   ],
   "server": [
     "OnServerPlayerDeath"


### PR DESCRIPTION
The data doesn't get copied over when the player dies or completes the end fight causing gyms to start stacking on top of each other. Fixes #44.