### PR TITLE
Added API and its first event LevelBoundsCallback, swapped dec and de…

### DIFF
--- a/src/main/java/lol/gito/radgyms/api/LevelBoundsResult.java
+++ b/src/main/java/lol/gito/radgyms/api/LevelBoundsResult.java
@@ -1,0 +1,43 @@
+package lol.gito.radgyms.api;
+
+/**
+ * Result for overriding level bounds.
+ * - maxOverride: if non-null, use as the max level.
+ * - enforceMin: if true AND minOverride is non-null, use that minimum.
+ */
+public final class LevelBoundsResult {
+    private final Integer minOverride;
+    private final Integer maxOverride;
+
+    private LevelBoundsResult(Integer minOverride, Integer maxOverride) {
+        this.maxOverride = maxOverride;
+        this.minOverride = minOverride;
+    }
+
+    public static LevelBoundsResult pass() {
+        return new LevelBoundsResult(null, null);
+    }
+
+    public static LevelBoundsResult overrideMax(int max) {
+        return new LevelBoundsResult(null, max);
+    }
+
+    public static LevelBoundsResult overrideMin(int min) {
+        return new LevelBoundsResult(min, null);
+    }
+
+    public static LevelBoundsResult override(int min, int max) {
+        return new LevelBoundsResult(min, max);
+    }
+
+    public Integer maxOverride() { return maxOverride; }
+    public Integer minOverride() { return minOverride; }
+
+    /** Merge two results; rhs takes precedence when non-null / true. */
+    public LevelBoundsResult merge(LevelBoundsResult rhs) {
+        if (rhs == null) return this;
+        Integer max = rhs.maxOverride != null ? rhs.maxOverride : this.maxOverride;
+        Integer min = rhs.minOverride != null ? rhs.minOverride : this.minOverride;
+        return new LevelBoundsResult(min, max);
+    }
+}

--- a/src/main/java/lol/gito/radgyms/api/RadGymsApi.java
+++ b/src/main/java/lol/gito/radgyms/api/RadGymsApi.java
@@ -1,0 +1,7 @@
+package lol.gito.radgyms.api;
+
+/** Public API marker for RADGyms. */
+public final class RadGymsApi {
+    public static final String API_VERSION = "0.1.0";
+    private RadGymsApi() {}
+}

--- a/src/main/java/lol/gito/radgyms/api/context/LevelBoundsContext.java
+++ b/src/main/java/lol/gito/radgyms/api/context/LevelBoundsContext.java
@@ -1,0 +1,9 @@
+package lol.gito.radgyms.api.context;
+
+import net.minecraft.client.gui.widget.SliderWidget;
+
+/**
+ * Context for deciding level bounds for the level slider.
+ * Kept minimal and client-safe.
+ */
+public record LevelBoundsContext(int defaultMin, int defaultMax) {}

--- a/src/main/java/lol/gito/radgyms/api/event/LevelBoundsCallback.java
+++ b/src/main/java/lol/gito/radgyms/api/event/LevelBoundsCallback.java
@@ -1,0 +1,32 @@
+package lol.gito.radgyms.api.event;
+
+import lol.gito.radgyms.api.LevelBoundsResult;
+import lol.gito.radgyms.api.context.LevelBoundsContext;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+/**
+ * Fired when the level slider computes its min/max bounds.
+ * Listeners can override the max, and optionally enforce a minimum.
+ *
+ * Multiple listeners are merged; later listeners take precedence.
+ */
+@FunctionalInterface
+public interface LevelBoundsCallback {
+    Event<LevelBoundsCallback> EVENT = EventFactory.createArrayBacked(
+            LevelBoundsCallback.class,
+            listeners -> ctx -> {
+                LevelBoundsResult acc = LevelBoundsResult.pass();
+                for (LevelBoundsCallback l : listeners) {
+                    LevelBoundsResult r = l.onDecideBounds(ctx);
+                    if (r != null) acc = acc.merge(r);
+                }
+                return acc;
+            }
+    );
+
+    /**
+     * @return a LevelBoundsResult (or null to pass) describing overrides.
+     */
+    LevelBoundsResult onDecideBounds(LevelBoundsContext ctx);
+}

--- a/src/main/kotlin/lol/gito/radgyms/client/gui/screen/GymEnterScreen.kt
+++ b/src/main/kotlin/lol/gito/radgyms/client/gui/screen/GymEnterScreen.kt
@@ -13,6 +13,8 @@ import com.cobblemon.mod.common.api.gui.blitk
 import com.cobblemon.mod.common.api.types.ElementalTypes
 import com.cobblemon.mod.common.client.gui.CobblemonRenderable
 import com.cobblemon.mod.common.client.render.drawScaledText
+import lol.gito.radgyms.api.context.LevelBoundsContext
+import lol.gito.radgyms.api.event.LevelBoundsCallback
 import lol.gito.radgyms.client.gui.widget.LevelSliderWidget
 import lol.gito.radgyms.client.radGymsResource
 import lol.gito.radgyms.common.RadGyms.debug
@@ -84,9 +86,21 @@ class GymEnterScreen(val key: Boolean, val type: String? = null, val pos: BlockP
     override fun close() = this.client!!.setScreen(null)
 
     override fun init() {
+        val defaultMin = 10
+        val defaultMax = Cobblemon.config.maxPokemonLevel
+
+        val res = LevelBoundsCallback.EVENT.invoker().onDecideBounds(LevelBoundsContext(defaultMin, defaultMax))
+
+        val minLevel = res.minOverride() ?: defaultMin;
+        val maxLevel = res.maxOverride() ?: defaultMax;
+
+        this.level = this.level.coerceIn(minLevel, maxLevel)
+
         val levelSelectSlider = LevelSliderWidget(
             x = leftX + 55,
             y = topY + 25,
+            minLevel,
+            maxLevel
         ) { level ->
             this.level = level
             this.tick()
@@ -94,25 +108,25 @@ class GymEnterScreen(val key: Boolean, val type: String? = null, val pos: BlockP
 
         val decButton = ButtonWidget
             .builder(Text.of("-1")) {
-                level = level.dec().coerceIn(10, Cobblemon.config.maxPokemonLevel)
+                level = level.dec().coerceIn(minLevel, maxLevel)
                 levelSelectSlider.updateLevel(level)
             }
             .size(20, 20)
-            .position(leftX + 10, topY + 25)
+            .position(leftX + 35, topY + 25)
             .build()
 
         val dec10Button = ButtonWidget
             .builder(Text.of("-10")) {
-                level = level.minus(10).coerceIn(10, Cobblemon.config.maxPokemonLevel)
+                level = level.minus(10).coerceIn(minLevel, maxLevel)
                 levelSelectSlider.updateLevel(level)
             }
             .size(25, 20)
-            .position(leftX + 30, topY + 25)
+            .position(leftX + 10, topY + 25)
             .build()
 
         val incButton = ButtonWidget
             .builder(Text.of("+1")) {
-                level = level.inc().coerceIn(10, Cobblemon.config.maxPokemonLevel)
+                level = level.inc().coerceIn(minLevel, maxLevel)
                 levelSelectSlider.updateLevel(level)
             }
             .size(20, 20)
@@ -121,7 +135,7 @@ class GymEnterScreen(val key: Boolean, val type: String? = null, val pos: BlockP
 
         val inc10Button = ButtonWidget
             .builder(Text.of("+10")) {
-                level = level.plus(10).coerceIn(10, Cobblemon.config.maxPokemonLevel)
+                level = level.plus(10).coerceIn(minLevel, maxLevel)
                 levelSelectSlider.updateLevel(level)
             }
             .size(25, 20)
@@ -145,8 +159,8 @@ class GymEnterScreen(val key: Boolean, val type: String? = null, val pos: BlockP
             .build()
 
         this.addDrawableChild(levelSelectSlider)
-        this.addDrawableChild(decButton)
         this.addDrawableChild(dec10Button)
+        this.addDrawableChild(decButton)
         this.addDrawableChild(incButton)
         this.addDrawableChild(inc10Button)
         this.addDrawableChild(proceedButton)

--- a/src/main/kotlin/lol/gito/radgyms/common/RadGyms.kt
+++ b/src/main/kotlin/lol/gito/radgyms/common/RadGyms.kt
@@ -58,7 +58,6 @@ object RadGyms {
 
         // Network
         CommonNetworkStack.register()
-
     }
 
     fun modId(name: String): Identifier {


### PR DESCRIPTION
# RAD Gyms public developer API

This PR introduces a small Java API to be expanded on in future PRs.  The first feature is adding a callback to the gym entrance screen with options to override the min and max level the user is allowed to pick.

If no developer registers callbacks to this event, the functionality is unchanged, the range is set between 10-100.

The API allows developers to optionally override the minimum and maximum of the `LevelSliderWidget`. The callback uses primitive types and is safe on both server and client consumers.

## Context

I'm working on [Ultimate Cobblemon Progression](https://github.com/ppVon/ultimate-cobblemon-progression) which aims to add a lot more progression into cobblemon by implementing a "Trainer Level" that corresponds with a data-configurable level cap and list of species.  I'd like completing a gym at the level cap to be the natural way for the player to progress through these player tiers, and RAD Gyms is the best option, but I need some API hooks to:

1. Limit the level of gyms players can use (this pr)
2. Apply additional filters to the species generated teams can use
3. Apply some level variance instead of just all mon levels = gym level
4. Increment the player level when they complete a gym whos level is their current player level level cap.

I started implementing this with mixins but uh... yeah.  Since this project is open to contributions I think a developer API is a great addition.

Example Pseudo-code Usage:

```java
LevelBoundsCallback.EVENT.register(ctx -> {
    // Config setting to limit min gym level by previous level cap
    int trainerMin = previous playerlevel level cap;
    int trainerMax = current playerlevel level cap;
    return LevelBoundsResult.override(trainerMin, trainerMax);
});
```

## Side-effects

I also swapped the `dec` and `dec10` buttons because it made more sense to me to have them in this order: [-10, -1, slider, +1, +10], but can revert that.