### PR TITLE
fix: additional checks on server cleanup to prevent shutdown NPE

### DIFF
--- a/src/main/kotlin/lol/gito/radgyms/common/RadGyms.kt
+++ b/src/main/kotlin/lol/gito/radgyms/common/RadGyms.kt
@@ -66,14 +66,14 @@ object RadGyms {
     fun modId(name: String): ResourceLocation = ResourceLocation.fromNamespaceAndPath(MOD_ID, name)
 
     @Suppress("unused")
-    fun log(message: String): Unit = LOGGER.info(message)
+    fun log(message: String, vararg params: Any): Unit = LOGGER.info(message, *params)
 
     @Suppress("unused")
-    fun warn(message: String): Unit = LOGGER.warn(message)
+    fun warn(message: String, vararg params: Any): Unit = LOGGER.warn(message, *params)
 
     @Suppress("unused")
-    fun debug(message: String) {
-        if (CONFIG.debug == true) LOGGER.info(message)
+    fun debug(message: String, vararg params: Any) {
+        if (CONFIG.debug == true) LOGGER.info(message, *params)
     }
 
     @OptIn(ExperimentalSerializationApi::class)

--- a/src/main/kotlin/lol/gito/radgyms/common/gym/GymTeardownService.kt
+++ b/src/main/kotlin/lol/gito/radgyms/common/gym/GymTeardownService.kt
@@ -44,15 +44,10 @@ object GymTeardownService {
         RadGymsState.removeGymForPlayer(serverPlayer)
     }
 
-    fun destructOfflineGym(server: MinecraftServer, uuid: UUID, gym: Gym?) {
+    fun destructOfflineGym(server: MinecraftServer, uuid: UUID, gym: Gym) {
         val world = server.getLevel(RadGymsDimensions.RADGYMS_LEVEL_KEY)!!
 
-        var derived = gym
-        if (derived == null) {
-            derived = RadGymsState.getServerState(server).gymInstanceMap[uuid]!!
-        }
-
-        derived.npcList.forEach {
+        gym.npcList.forEach {
             RadGyms.RCT.trainerRegistry.unregisterById(it.key.toString())
             world.getEntity(it.key)?.discard()
         }

--- a/src/main/kotlin/lol/gito/radgyms/common/state/RadGymsState.kt
+++ b/src/main/kotlin/lol/gito/radgyms/common/state/RadGymsState.kt
@@ -11,17 +11,18 @@ import com.cobblemon.mod.common.api.pokemon.PokemonPropertyExtractor
 import com.gitlab.srcmc.rctapi.api.trainer.TrainerNPC
 import lol.gito.radgyms.common.RadGyms
 import lol.gito.radgyms.common.RadGyms.MOD_ID
+import lol.gito.radgyms.common.RadGyms.debug
 import lol.gito.radgyms.common.api.dto.Gym
 import lol.gito.radgyms.common.registry.RadGymsDimensions.RADGYMS_LEVEL_KEY
 import lol.gito.radgyms.common.util.getBlockPos
 import lol.gito.radgyms.common.util.putBlockPos
+import lol.gito.radgyms.fabric.RadGymsFabric.server
 import lol.gito.radgyms.mixin.util.accessor.RCTBattleAIAccessor
 import net.minecraft.core.HolderLookup
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.level.ServerPlayer
-import net.minecraft.world.entity.player.Player
 import net.minecraft.world.level.saveddata.SavedData
 import java.util.*
 
@@ -72,8 +73,8 @@ class RadGymsState : SavedData() {
             }
         }
 
-        fun getPlayerState(player: Player): PlayerData {
-            val serverState = getServerState(player.server!!)
+        fun getPlayerState(player: ServerPlayer): PlayerData {
+            val serverState = getServerState(player.server)
 
             return serverState.playerDataMap.computeIfAbsent(player.uuid) { PlayerData() }
         }
@@ -107,7 +108,10 @@ class RadGymsState : SavedData() {
         }
 
         fun removeGymForPlayerByUuid(uuid: UUID) {
-            getServerState(RadGyms.implementation.server()!!).gymInstanceMap.remove(uuid)
+            server()?.let {
+                debug("Removing gyms for player {}", uuid)
+                getServerState(it).gymInstanceMap.remove(uuid)
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes probable NPE on server stopping event by introducing additional null checks on server instance and forcibly setting the server instance in fabric impl

Closes #96 