### PR TITLE
0.3.x fix crash caused by disconnects

### DIFF
--- a/src/main/kotlin/lol/gito/radgyms/common/event/EventManager.kt
+++ b/src/main/kotlin/lol/gito/radgyms/common/event/EventManager.kt
@@ -135,6 +135,7 @@ object EventManager {
         debug("Removing player ${event.player.name} from RCT trainer mod registry")
         RCT.trainerRegistry.unregisterById(event.player.uuid.toString())
 
+        if (RadGymsState.getGymForPlayer(event.player) == null) return
         if (event.player.level().dimension() == RadGymsDimensions.RADGYMS_LEVEL_KEY) {
             GymTeardownService.spawnExitBlock(event.player.server, RadGymsState.getGymForPlayer(event.player)!!)
             GymTeardownService.destructGym(event.player, removeCoords = false)


### PR DESCRIPTION
We encountered this issue on a server when a player disconnected, reconnected, and then disconnected again while in the gym dimension. This resolves that by simply terminating early on the event if the user does not have a gym associated to them.

```
[09:08:06] [Server thread/ERROR]: Error executing task on Server
java.lang.NullPointerException: null
	at knot/lol.gito.radgyms.common.event.EventManager.onPlayerDisconnect(EventManager.kt:139) ~[Rad-Gyms-0.3.1-stable.jar:?]
	at knot/lol.gito.radgyms.common.event.EventManager.access$onPlayerDisconnect(EventManager.kt:50) ~[Rad-Gyms-0.3.1-stable.jar:?]
	at knot/lol.gito.radgyms.common.event.EventManager$register$4.invoke(EventManager.kt:57) ~[Rad-Gyms-0.3.1-stable.jar:?]
	at knot/lol.gito.radgyms.common.event.EventManager$register$4.invoke(EventManager.kt:57) ~[Rad-Gyms-0.3.1-stable.jar:?]
	at knot/com.cobblemon.mod.common.api.reactive.ObservableSubscription.handle(ObservableSubscription.java:16) ~[cobblemon.jar:?]
	at knot/com.cobblemon.mod.common.api.reactive.SimpleObservable.emit(SimpleObservable.java:39) ~[cobblemon.jar:?]
	at knot/com.cobblemon.mod.fabric.CobblemonFabric.initialize$lambda$15$0(CobblemonFabric.kt:561) ~[cobblemon.jar:?]
	at knot/net.minecraft.class_3738.run(class_3738.java:18) ~[server-intermediary.jar:?]
	at knot/net.minecraft.class_1255.method_18859(class_1255.java:162) ~[server-intermediary.jar:?]
	at knot/net.minecraft.class_4093.method_18859(class_4093.java:23) ~[server-intermediary.jar:?]
	at knot/net.minecraft.server.MinecraftServer.method_24306(MinecraftServer.java:864) ~[server-intermediary.jar:?]
	at knot/net.minecraft.server.MinecraftServer.method_18859(MinecraftServer.java:173) ~[server-intermediary.jar:?]
	at knot/net.minecraft.class_1255.method_16075(class_1255.java:136) ~[server-intermediary.jar:?]
	at knot/net.minecraft.server.MinecraftServer.method_20415(MinecraftServer.java:846) ~[server-intermediary.jar:?]
	at knot/net.minecraft.server.MinecraftServer.method_16075(MinecraftServer.java:840) ~[server-intermediary.jar:?]
	at knot/net.minecraft.class_1255.method_18857(class_1255.java:145) ~[server-intermediary.jar:?]
	at knot/net.minecraft.server.MinecraftServer.method_18857(MinecraftServer.java:810) ~[server-intermediary.jar:?]
	at knot/net.minecraft.server.MinecraftServer.mixinextras$bridge$method_18857$322(MinecraftServer.java) ~[server-intermediary.jar:?]
	at knot/net.minecraft.server.MinecraftServer.wrapOperation$cgk000$modernfix$managedBlock(MinecraftServer.java:2123) ~[server-intermediary.jar:?]
	at knot/net.minecraft.server.MinecraftServer.method_16208(MinecraftServer.java:815) ~[server-intermediary.jar:?]
	at knot/net.minecraft.server.MinecraftServer.method_29741(MinecraftServer.java:702) ~[server-intermediary.jar:?]
	at knot/net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:281) ~[server-intermediary.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```