### PR TITLE
Datapack improvements

### DIFF
--- a/common/src/main/kotlin/lol/gito/radgyms/common/api/dto/TrainerModel.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/api/dto/TrainerModel.kt
@@ -113,6 +113,7 @@ data class TrainerModel(
                 @SerialName("max_select_margin")
                 val maxSelectMargin: Double? = null,
                 // StrongBattleAI
+                @SerialName("skill_level")
                 val skillLevel: Int? = null
             )
         }


### PR DESCRIPTION
## Description
Introduced `Threshold` data class for defining gym team thresholds in gym datapack definitions.
Changed `skillLevel` serial name to `skill_level`
 
## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update