### PR TITLE
New team generators: `PoolTeamGenerator` and `FixedTeamGenerator`

### DIFF
--- a/common/src/main/kotlin/lol/gito/radgyms/common/api/dto/Gym.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/api/dto/Gym.kt
@@ -47,17 +47,17 @@ data class Gym(
             ),
             LootTableInfo(
                 id = "rad_gyms:gyms/default/uncommon_loot_table",
-                minLevel =  26,
+                minLevel = 26,
                 maxLevel = 50
             ),
             LootTableInfo(
                 id = "rad_gyms:gyms/default/rare_loot_table",
-                minLevel =  51,
+                minLevel = 51,
                 maxLevel = 75
             ),
             LootTableInfo(
                 id = "rad_gyms:gyms/default/epic_loot_table",
-                minLevel =  76
+                minLevel = 76
             ),
         )
     ) {

--- a/common/src/main/kotlin/lol/gito/radgyms/common/api/dto/TrainerModel.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/api/dto/TrainerModel.kt
@@ -51,12 +51,12 @@ data class TrainerModel(
             val teamGenerator: GymTeamGeneratorType = GymTeamGeneratorType.CHAOTIC,
             @Contextual
             @SerialName("possible_elemental_types")
-            val possibleElementalTypes: ElementalListType? = listOf(
+            val possibleElementalTypes: ElementalListType = listOf(
                 ElementalTypes.getRandomType()
             ),
             @SerialName("possible_formats")
             val possibleFormats: List<GymBattleFormat> = listOf(GymBattleFormat.SINGLES),
-            val ai: AI = AI("rct"),
+            val ai: AI = AI(),
             val bag: List<Bag> = listOf(
                 Bag("cobblemon:hyper_potion", 2)
             ),
@@ -71,7 +71,7 @@ data class TrainerModel(
             val battleRules: BattleRules = BattleRules(),
             val team: List<String> = emptyList(),
             val leader: Boolean = false,
-            val requires: String? = null,
+            val requires: String? = null
         ) {
             init {
                 teamType.let {
@@ -96,7 +96,7 @@ data class TrainerModel(
 
         @Serializable
         data class AI(
-            val type: String,
+            val type: String = "rct",
             val data: Config? = null,
         ) {
             @Serializable

--- a/common/src/main/kotlin/lol/gito/radgyms/common/api/enumeration/GymBattleFormat.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/api/enumeration/GymBattleFormat.kt
@@ -11,10 +11,11 @@ import com.gitlab.srcmc.rctapi.api.battle.BattleFormat
 import com.gitlab.srcmc.rctapi.api.battle.BattleFormatProvider
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import net.minecraft.util.StringRepresentable
 import com.cobblemon.mod.common.battles.BattleFormat as CBattleFormat
 
 @Serializable
-enum class GymBattleFormat: BattleFormatProvider {
+enum class GymBattleFormat : BattleFormatProvider, StringRepresentable {
     @JvmField
     @SerialName("singles")
     SINGLES {
@@ -33,7 +34,15 @@ enum class GymBattleFormat: BattleFormatProvider {
         override val format: BattleFormat = BattleFormat.GEN_9_TRIPLES
     };
 
+    override fun getSerializedName(): String = this.name
+
     abstract val format: BattleFormat
 
     override fun getCobblemonBattleFormat(): CBattleFormat = this.format.cobblemonBattleFormat
+
+    companion object {
+        @JvmField
+        @Transient
+        val CODEC = StringRepresentable.fromEnum { entries.toTypedArray() }
+    }
 }

--- a/common/src/main/kotlin/lol/gito/radgyms/common/api/enumeration/GymTeamGeneratorType.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/api/enumeration/GymTeamGeneratorType.kt
@@ -12,9 +12,10 @@ import kotlinx.serialization.Serializable
 import lol.gito.radgyms.common.gym.team.BstTeamGenerator
 import lol.gito.radgyms.common.gym.team.ChaoticTeamGenerator
 import lol.gito.radgyms.common.gym.team.GenericTeamGenerator
+import net.minecraft.util.StringRepresentable
 
 @Serializable
-enum class GymTeamGeneratorType {
+enum class GymTeamGeneratorType : StringRepresentable {
     @JvmField
     @SerialName("bst")
     BST {
@@ -27,5 +28,13 @@ enum class GymTeamGeneratorType {
         override val instance: GenericTeamGenerator = ChaoticTeamGenerator()
     };
 
+    override fun getSerializedName(): String = this.name
+
     abstract val instance: GenericTeamGenerator
+
+    companion object {
+        @JvmField
+        @Transient
+        val CODEC = StringRepresentable.fromEnum { entries.toTypedArray() }
+    }
 }

--- a/common/src/main/kotlin/lol/gito/radgyms/common/api/enumeration/GymTeamType.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/api/enumeration/GymTeamType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025. gitoido-mc
+ * Copyright (c) 2025-2026. gitoido-mc
  * This Source Code Form is subject to the terms of the GNU General Public License v3.0.
  * If a copy of the GNU General Public License v3.0 was not distributed with this file,
  * you can obtain one at https://github.com/gitoido-mc/rad-gyms/blob/main/LICENSE.
@@ -9,9 +9,10 @@ package lol.gito.radgyms.common.api.enumeration
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import net.minecraft.util.StringRepresentable
 
 @Serializable
-enum class GymTeamType {
+enum class GymTeamType : StringRepresentable {
     @JvmField
     @SerialName("generated")
     GENERATED,
@@ -22,5 +23,12 @@ enum class GymTeamType {
 
     @JvmField
     @SerialName("pool")
-    POOL
+    POOL;
+    override fun getSerializedName(): String = this.name
+
+    companion object {
+        @JvmField
+        @Transient
+        val CODEC = StringRepresentable.fromEnum { entries.toTypedArray() }
+    }
 }

--- a/common/src/main/kotlin/lol/gito/radgyms/common/api/serialization/RadGymsCodec.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/api/serialization/RadGymsCodec.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026. gitoido-mc
+ * This Source Code Form is subject to the terms of the GNU General Public License v3.0.
+ * If a copy of the GNU General Public License v3.0 was not distributed with this file,
+ * you can obtain one at https://github.com/gitoido-mc/rad-gyms/blob/main/LICENSE.
+ */
+
+package lol.gito.radgyms.common.api.serialization
+
+import com.cobblemon.mod.common.api.types.ElementalType
+import com.mojang.serialization.Codec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import lol.gito.radgyms.common.api.dto.Gym.Json
+import lol.gito.radgyms.common.api.dto.Gym.Json.*
+import lol.gito.radgyms.common.api.dto.TrainerModel.Json.AI
+import lol.gito.radgyms.common.api.dto.TrainerModel.Json.AI.Config
+import lol.gito.radgyms.common.api.dto.TrainerModel.Json.Bag
+import lol.gito.radgyms.common.api.dto.TrainerModel.Json.BattleRules
+import lol.gito.radgyms.common.api.dto.TrainerModel.Json.Threshold
+import lol.gito.radgyms.common.api.dto.TrainerModel.Json.Trainer
+import lol.gito.radgyms.common.api.enumeration.GymBattleFormat
+import lol.gito.radgyms.common.api.enumeration.GymTeamGeneratorType
+import lol.gito.radgyms.common.api.enumeration.GymTeamType
+
+object RadGymsCodec {
+    @JvmStatic
+    val COORDS: Codec<Coords> = RecordCodecBuilder.create {
+        it.group(
+            Codec.DOUBLE.fieldOf("x").forGetter(Coords::x),
+            Codec.DOUBLE.fieldOf("y").forGetter(Coords::y),
+            Codec.DOUBLE.fieldOf("z").forGetter(Coords::z)
+        ).apply(it, ::Coords)
+    }
+
+    @JvmStatic
+    val ENTITY_COORDS_YAW: Codec<EntityCoordsAndYaw> = RecordCodecBuilder.create {
+        it.group(
+            COORDS.fieldOf("pos").forGetter(EntityCoordsAndYaw::pos),
+            Codec.DOUBLE.fieldOf("yaw").forGetter(EntityCoordsAndYaw::yaw)
+        ).apply(it, ::EntityCoordsAndYaw)
+    }
+
+    @JvmStatic
+    val LOOT_TABLE_INFO: Codec<LootTableInfo> = RecordCodecBuilder.create {
+        it.group(
+            Codec.STRING.fieldOf("id").forGetter(LootTableInfo::id),
+            Codec.INT.fieldOf("min_level").forGetter(LootTableInfo::minLevel),
+            Codec.INT.fieldOf("max_level").forGetter(LootTableInfo::maxLevel),
+        ).apply(it, ::LootTableInfo)
+    }
+
+    @JvmStatic
+    val THRESHOLD: Codec<Threshold> = RecordCodecBuilder.create {
+        it.group(
+            Codec.INT.fieldOf("amount").forGetter(Threshold::amount),
+            Codec.INT.fieldOf("until_level").forGetter(Threshold::untilLevel),
+        ).apply(it, ::Threshold)
+    }
+
+    @JvmStatic
+    val BAG: Codec<Bag> = RecordCodecBuilder.create {
+        it.group(
+            Codec.STRING.fieldOf("item").forGetter(Bag::item),
+            Codec.INT.fieldOf("quantity").forGetter(Bag::quantity)
+        ).apply(it, ::Bag)
+    }
+
+    @JvmStatic
+    val AI_CONFIG: Codec<Config> = RecordCodecBuilder.create {
+        it.group(
+            Codec.DOUBLE.lenientOptionalFieldOf("move_bias", null).forGetter(Config::moveBias),
+            Codec.DOUBLE.lenientOptionalFieldOf("status_move_bias", null).forGetter(Config::statusMoveBias),
+            Codec.DOUBLE.lenientOptionalFieldOf("switch_bias", null).forGetter(Config::switchBias),
+            Codec.DOUBLE.lenientOptionalFieldOf("item_bias", null).forGetter(Config::itemBias),
+            Codec.DOUBLE.lenientOptionalFieldOf("max_select_margin", null).forGetter(Config::maxSelectMargin),
+            Codec.INT.lenientOptionalFieldOf("skill_level", null).forGetter(Config::skillLevel)
+        ).apply(it, ::Config)
+    }
+
+    @JvmStatic
+    val TRAINER_AI: Codec<AI> = RecordCodecBuilder.create {
+        it.group(
+            Codec.STRING.fieldOf("type").forGetter(AI::type),
+            AI_CONFIG.optionalFieldOf("data", null).forGetter(AI::data)
+        ).apply(it, ::AI)
+    }
+
+    @JvmStatic
+    val BATTLE_RULES: Codec<BattleRules> = RecordCodecBuilder.create {
+        it.group(
+            Codec.INT.fieldOf("type").forGetter(BattleRules::maxItemUses)
+        ).apply(it, ::BattleRules)
+    }
+
+    @JvmStatic
+    val TRAINER: Codec<Trainer> = RecordCodecBuilder.create {
+        it.group(
+            Codec.STRING.fieldOf("id").forGetter(Trainer::id),
+            Codec.STRING.fieldOf("name").forGetter(Trainer::name),
+            ENTITY_COORDS_YAW.fieldOf("spawn_relative").forGetter(Trainer::spawnRelative),
+            GymTeamType.CODEC.fieldOf("team_type").forGetter(Trainer::teamType),
+            GymTeamGeneratorType.CODEC.fieldOf("team_generator").forGetter(Trainer::teamGenerator),
+            Codec.list(ElementalType.BY_STRING_CODEC).fieldOf("possible_elemental_types")
+                .forGetter(Trainer::possibleElementalTypes),
+            Codec.list(GymBattleFormat.CODEC).fieldOf("possible_formats").forGetter(Trainer::possibleFormats),
+            TRAINER_AI.fieldOf("ai").forGetter(Trainer::ai),
+            Codec.list(BAG).fieldOf("bag").forGetter(Trainer::bag),
+            Codec.list(THRESHOLD).fieldOf("level_thresholds").forGetter(Trainer::countPerLevelThreshold),
+            BATTLE_RULES.fieldOf("battle_rules").forGetter(Trainer::battleRules),
+            Codec.list(Codec.STRING).fieldOf("team").forGetter(Trainer::team),
+            Codec.BOOL.fieldOf("leader").forGetter(Trainer::leader),
+            Codec.STRING.lenientOptionalFieldOf("requires", null).forGetter(Trainer::requires)
+        ).apply(it, ::Trainer)
+    }
+
+    val GYM: Codec<Json> = RecordCodecBuilder.create {
+        it.group(
+            Codec.STRING.fieldOf("interior_template").forGetter(Json::template),
+            COORDS.fieldOf("exit_block_pos").forGetter(Json::exitBlockPos),
+            ENTITY_COORDS_YAW.fieldOf("player_spawn_relative").forGetter(Json::playerSpawnRelative),
+            Codec.list(TRAINER).fieldOf("trainers").forGetter(Json::trainers),
+            Codec.list(LOOT_TABLE_INFO).fieldOf("reward_loot_tables").forGetter(Json::rewardLootTables)
+        ).apply(it, ::Json)
+    }
+}

--- a/common/src/main/kotlin/lol/gito/radgyms/common/api/team/TeamGeneratorInterface.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/api/team/TeamGeneratorInterface.kt
@@ -7,9 +7,9 @@
 
 package lol.gito.radgyms.common.api.team
 
-import com.cobblemon.mod.common.api.pokemon.PokemonProperties
 import com.cobblemon.mod.common.api.types.ElementalType
 import com.cobblemon.mod.common.api.types.ElementalTypes
+import com.cobblemon.mod.common.pokemon.Pokemon
 import com.gitlab.srcmc.rctapi.api.models.PokemonModel
 import lol.gito.radgyms.common.api.dto.TrainerModel
 import lol.gito.radgyms.common.api.enumeration.GymBattleFormat
@@ -20,15 +20,13 @@ interface TeamGeneratorInterface {
         trainer: TrainerModel.Json.Trainer,
         level: Int,
         player: ServerPlayer,
-        possibleFormats: MutableList<GymBattleFormat>,
-        types: List<ElementalType> = listOf(
-            ElementalTypes.getRandomType()
-        )
+        possibleFormats: MutableList<GymBattleFormat>? = mutableListOf(GymBattleFormat.SINGLES),
+        types: List<ElementalType>? = listOf(ElementalTypes.getRandomType())
     ): MutableList<PokemonModel>
 
     fun generatePokemon(
         level: Int,
         thresholdAmount: Int,
         type: ElementalType = ElementalTypes.getRandomType(),
-    ): PokemonProperties
+    ): Pokemon
 }

--- a/common/src/main/kotlin/lol/gito/radgyms/common/gym/GymTemplate.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/gym/GymTemplate.kt
@@ -8,9 +8,6 @@
 package lol.gito.radgyms.common.gym
 
 import lol.gito.radgyms.common.api.dto.Gym
-import lol.gito.radgyms.common.util.getVec3d
-import lol.gito.radgyms.common.util.putVec3d
-import net.minecraft.nbt.CompoundTag
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.phys.Vec3
 import lol.gito.radgyms.common.api.dto.TrainerModel as RGTrainerModel
@@ -46,33 +43,5 @@ data class GymTemplate(
                 lootTables = dto.rewardLootTables!!
             )
         }
-
-        fun fromNbt(tag: CompoundTag): GymTemplate {
-            // Basic primitive/vector decoding
-            val structure = tag.getString("structure")
-            val exit = tag.getVec3d("exit")
-            val player = tag.getVec3d("player")
-            val yaw = tag.getFloat("playerYaw")
-
-            // TODO: deserialize trainers & lootTables using knbt or JSON fallback
-            val trainers = emptyList<RGTrainerModel>()
-            val lootTables = emptyList<Gym.Json.LootTableInfo>()
-
-            return GymTemplate(structure, exit, player, yaw, trainers, tag.getString("type").ifBlank { null }, lootTables)
-        }
-    }
-
-    fun toNbt(): CompoundTag {
-        val tag = CompoundTag()
-        tag.putString("structure", structure)
-        tag.putVec3d("exit", relativeExitBlockSpawn)
-        tag.putVec3d("player", relativePlayerSpawn)
-        tag.putFloat("playerYaw", playerYaw)
-        tag.putString("type", type ?: "")
-
-        // TODO: serialize `trainers` and `lootTables` using knbt serialization helpers.
-        // Fallback approach: convert complex objects to JSON strings and store in NBT string list.
-
-        return tag
     }
 }

--- a/common/src/main/kotlin/lol/gito/radgyms/common/gym/TrainerFactory.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/gym/TrainerFactory.kt
@@ -7,8 +7,6 @@
 
 package lol.gito.radgyms.common.gym
 
-import com.cobblemon.mod.common.api.pokemon.PokemonProperties
-import com.cobblemon.mod.common.api.types.ElementalTypes
 import com.cobblemon.mod.common.battles.ai.StrongBattleAI
 import com.gitlab.srcmc.rctapi.api.ai.RCTBattleAI
 import com.gitlab.srcmc.rctapi.api.ai.config.StrongBattleAIConfig
@@ -17,7 +15,8 @@ import com.gitlab.srcmc.rctapi.api.battle.BattleRules
 import com.gitlab.srcmc.rctapi.api.models.BagItemModel
 import com.gitlab.srcmc.rctapi.api.util.JTO
 import lol.gito.radgyms.common.api.enumeration.GymTeamType
-import lol.gito.radgyms.common.gym.SpeciesManager.fillPokemonModelFromPokemon
+import lol.gito.radgyms.common.gym.team.FixedTeamGenerator
+import lol.gito.radgyms.common.gym.team.PoolTeamGenerator
 import net.minecraft.network.chat.Component.translatable
 import net.minecraft.server.level.ServerPlayer
 import com.gitlab.srcmc.rctapi.api.models.TrainerModel as RCTTrainerModel
@@ -31,48 +30,24 @@ class TrainerFactory(
     ): RGTrainerModel {
         val ai = when (trainer.ai.type) {
             "rct" -> RCTBattleAI(battleConfigBuilder.createFromDto(trainer.ai))
-            "cbl" -> StrongBattleAI(trainer.ai.data?.skillLevel?:run { StrongBattleAIConfig().skill() })
+            "cbl" -> StrongBattleAI(trainer.ai.data?.skillLevel ?: StrongBattleAIConfig().skill())
             "sd5" -> SelfdotGen5AI()
             else -> throw RuntimeException(
                 "Unknown battle AI type for trainer ${trainer.id}, passed ${trainer.ai.type}, supports only 'rct', 'cbl', 'sd5'"
             )
         }
 
-        val bag = trainer.bag.map { BagItemModel(it.item, it.quantity) }
         val possibleFormats = trainer.possibleFormats.toMutableList()
         val team = when (trainer.teamType) {
+            GymTeamType.FIXED -> FixedTeamGenerator().generateTeam(player, trainer, level)
+            GymTeamType.POOL -> PoolTeamGenerator().generateTeam(player, trainer, level)
             GymTeamType.GENERATED -> trainer.teamGenerator.instance.generateTeam(
                 trainer,
                 level,
                 player,
                 possibleFormats,
-                trainer.possibleElementalTypes?:run { ElementalTypes.all().shuffled().take(1) },
+                trainer.possibleElementalTypes,
             )
-
-            GymTeamType.POOL -> {
-                var pokemonCount = 1
-                // todo: make it better
-                for (mapperLevel in trainer.countPerLevelThreshold.sortedBy { it[0] }) {
-                    if (level >= mapperLevel[0]) pokemonCount = mapperLevel[1]
-                }
-                // now that we know amount of pokes we want to take - we fill the data
-                trainer.team
-                    .shuffled()
-                    .take(pokemonCount)
-                    .map { params ->
-                        val props = PokemonProperties.parse(params)
-
-                        fillPokemonModelFromPokemon(props)
-                    }
-                    .toMutableList()
-            }
-
-            GymTeamType.FIXED -> trainer.team
-                .map { params ->
-                    val props = PokemonProperties.parse("level=$level $params")
-                    fillPokemonModelFromPokemon(props)
-                }
-                .toMutableList()
         }
 
         return RGTrainerModel(
@@ -85,7 +60,7 @@ class TrainerFactory(
             RCTTrainerModel(
                 translatable(trainer.name).string,
                 JTO.of { ai },
-                bag,
+                trainer.bag.map { BagItemModel(it.item, it.quantity) },
                 team
             ),
             BattleRules(),

--- a/common/src/main/kotlin/lol/gito/radgyms/common/gym/team/BstTeamGenerator.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/gym/team/BstTeamGenerator.kt
@@ -7,14 +7,14 @@
 
 package lol.gito.radgyms.common.gym.team
 
-import com.cobblemon.mod.common.api.pokemon.PokemonProperties
 import com.cobblemon.mod.common.api.types.ElementalType
+import com.cobblemon.mod.common.pokemon.Pokemon
 import lol.gito.radgyms.common.RadGyms.CONFIG
 import lol.gito.radgyms.common.RadGyms.debug
 import lol.gito.radgyms.common.gym.SpeciesManager.SPECIES_BY_TYPE
 
 class BstTeamGenerator : GenericTeamGenerator() {
-    override fun generatePokemon(level: Int, thresholdAmount: Int, type: ElementalType): PokemonProperties {
+    override fun generatePokemon(level: Int, thresholdAmount: Int, type: ElementalType): Pokemon {
         debug("Rolling for pokemon with level $level and type ${type.showdownId}")
         val speciesList = SPECIES_BY_TYPE[type.showdownId]!!
 
@@ -37,6 +37,6 @@ class BstTeamGenerator : GenericTeamGenerator() {
                 it[derivedChunkIndex].random()
             }
 
-        return getPokemonProperties(derivedSpecies, level)
+        return getPokemon(derivedSpecies, level)
     }
 }

--- a/common/src/main/kotlin/lol/gito/radgyms/common/gym/team/FixedTeamGenerator.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/gym/team/FixedTeamGenerator.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026. gitoido-mc
+ * This Source Code Form is subject to the terms of the GNU General Public License v3.0.
+ * If a copy of the GNU General Public License v3.0 was not distributed with this file,
+ * you can obtain one at https://github.com/gitoido-mc/rad-gyms/blob/main/LICENSE.
+ */
+
+package lol.gito.radgyms.common.gym.team
+
+import com.cobblemon.mod.common.api.types.ElementalTypes
+import com.gitlab.srcmc.rctapi.api.models.PokemonModel
+import lol.gito.radgyms.common.api.dto.TrainerModel
+import lol.gito.radgyms.common.api.event.GymEvents
+import lol.gito.radgyms.common.api.event.GymEvents.GENERATE_TEAM
+import net.minecraft.server.level.ServerPlayer
+
+class FixedTeamGenerator : GenericTeamGenerator() {
+    fun generateTeam(player: ServerPlayer, trainer: TrainerModel.Json.Trainer, level: Int): MutableList<PokemonModel> {
+        val rawTeam = trainer
+            .team
+            .map { assembleProperties(level, it) }
+            .apply { this.forEach { it.updateAspects() } }
+            .toMutableList()
+
+        val possibleTypes = rawTeam
+            .map { ElementalTypes.get(it.type!!)!! }
+            .toMutableSet()
+
+        val event = GymEvents.GenerateTeamEvent(
+            player,
+            possibleTypes.toList(),
+            level,
+            trainer.id,
+            trainer.leader,
+            rawTeam,
+            trainer.possibleFormats.toMutableList()
+        )
+
+        val team = mutableListOf<PokemonModel>()
+
+        GENERATE_TEAM.post(event) { generated ->
+            generated.team.forEach { props ->
+                team.add(createPokemonModel(props))
+            }
+        }
+
+        return team
+    }
+}

--- a/common/src/main/kotlin/lol/gito/radgyms/common/gym/team/PoolTeamGenerator.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/gym/team/PoolTeamGenerator.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026. gitoido-mc
+ * This Source Code Form is subject to the terms of the GNU General Public License v3.0.
+ * If a copy of the GNU General Public License v3.0 was not distributed with this file,
+ * you can obtain one at https://github.com/gitoido-mc/rad-gyms/blob/main/LICENSE.
+ */
+
+package lol.gito.radgyms.common.gym.team
+
+import com.cobblemon.mod.common.api.types.ElementalTypes
+import com.gitlab.srcmc.rctapi.api.models.PokemonModel
+import lol.gito.radgyms.common.api.dto.TrainerModel
+import lol.gito.radgyms.common.api.event.GymEvents
+import lol.gito.radgyms.common.api.event.GymEvents.GENERATE_TEAM
+import net.minecraft.server.level.ServerPlayer
+
+class PoolTeamGenerator : GenericTeamGenerator() {
+    fun generateTeam(player: ServerPlayer, trainer: TrainerModel.Json.Trainer, level: Int): MutableList<PokemonModel> {
+        val pokemonCount = trainer
+            .countPerLevelThreshold
+            .filter { it.untilLevel >= level }
+            .minByOrNull { it.untilLevel }
+            ?.amount ?: 1
+
+        val rawTeam = trainer.team
+            .shuffled()
+            .take(pokemonCount)
+            .map { assembleProperties(level, it) }
+            .apply { this.forEach { it.updateAspects() } }
+            .toMutableList()
+
+        val possibleTypes = rawTeam
+            .map { ElementalTypes.get(it.type!!)!! }
+            .toMutableSet()
+
+        val event = GymEvents.GenerateTeamEvent(
+            player,
+            possibleTypes.toList(),
+            level,
+            trainer.id,
+            trainer.leader,
+            rawTeam,
+            trainer.possibleFormats.toMutableList()
+        )
+
+        val team = mutableListOf<PokemonModel>()
+
+        GENERATE_TEAM.post(event) { generated ->
+            generated.team.forEach { props ->
+                team.add(createPokemonModel(props))
+            }
+        }
+
+        return team
+    }
+}


### PR DESCRIPTION
## Description
* Optional `possible_elemental_types` and `ai` fields in gym datapack definition.
* Most of the json DTOs acquired proper codecs
* `GymBattleFormat`, `GymTeamGeneratorType` and `GymTeamType` enums now implement `StringRepresentable`, whicl allowed to define proper codecs for them
* Consolidated assembly and generation of trainers team species into abstract `GenericTeamGenerator` class
* Minor code refactors

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Checklist
- [X] Assembled mod jars work in production environment
