### PR TITLE
Modify elemental type checks and add missing fairy type

### DIFF
--- a/common/src/main/kotlin/lol/gito/radgyms/common/RadGymsConstant.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/RadGymsConstant.kt
@@ -49,6 +49,7 @@ val defaultElementalTypes = setOf(
     ElementalTypes.DARK.showdownId,
     ElementalTypes.DRAGON.showdownId,
     ElementalTypes.ELECTRIC.showdownId,
+    ElementalTypes.FAIRY.showdownId,
     ElementalTypes.FLYING.showdownId,
     ElementalTypes.FIGHTING.showdownId,
     ElementalTypes.FIRE.showdownId,

--- a/common/src/main/kotlin/lol/gito/radgyms/common/block/entity/GymEntranceEntity.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/block/entity/GymEntranceEntity.kt
@@ -7,9 +7,9 @@
 
 package lol.gito.radgyms.common.block.entity
 
-import com.cobblemon.mod.common.api.types.ElementalTypes
 import lol.gito.radgyms.common.RadGyms.config
 import lol.gito.radgyms.common.RadGyms.debug
+import lol.gito.radgyms.common.defaultElementalTypes
 import lol.gito.radgyms.common.registry.RadGymsBlockEntities
 import net.minecraft.core.BlockPos
 import net.minecraft.core.HolderLookup
@@ -30,7 +30,7 @@ class GymEntranceEntity(val pos: BlockPos, state: BlockState) :
     private val playerUsageDataKey = "playerEntries"
     private val gymTypeKey = "type"
     private var playerUseCounter: MutableMap<String, Int> = mutableMapOf()
-    var gymType: String = ElementalTypes.all().random().showdownId
+    var gymType: String = defaultElementalTypes.random()
 
     fun incrementPlayerUseCount(player: Player) {
         playerUseCounter[player.uuid.toString()] = playerUseCounter

--- a/common/src/main/kotlin/lol/gito/radgyms/common/cache/CacheHandler.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/cache/CacheHandler.kt
@@ -11,6 +11,7 @@ import com.cobblemon.mod.common.api.pokemon.PokemonProperties
 import com.cobblemon.mod.common.api.types.ElementalType
 import com.cobblemon.mod.common.api.types.ElementalTypes
 import com.cobblemon.mod.common.pokemon.Pokemon
+import lol.gito.radgyms.common.defaultElementalTypes
 import lol.gito.radgyms.common.exception.RadGymsPoolNotDefinedException
 import lol.gito.radgyms.common.extension.shinyRoll
 import lol.gito.radgyms.common.registry.RadGymsSpeciesRegistry.speciesByRarity
@@ -19,7 +20,7 @@ import net.minecraft.world.item.Rarity
 
 object CacheHandler {
     fun getPoke(type: String, rarity: Rarity, player: ServerPlayer, shinyBoost: Int = 0): Pokemon = getPoke(
-        ElementalTypes.get(type) ?: ElementalTypes.all().random(),
+        ElementalTypes.get(type) ?: ElementalTypes.getOrException(defaultElementalTypes.random()),
         rarity,
         player,
         shinyBoost,

--- a/common/src/main/kotlin/lol/gito/radgyms/common/client/render/gui/screen/GymEnterScreen.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/client/render/gui/screen/GymEnterScreen.kt
@@ -7,7 +7,6 @@
 
 package lol.gito.radgyms.common.client.render.gui.screen
 
-import com.cobblemon.mod.common.api.types.ElementalTypes
 import com.cobblemon.mod.common.client.render.drawScaledText
 import lol.gito.radgyms.common.RadGyms
 import lol.gito.radgyms.common.RadGyms.modId
@@ -15,6 +14,7 @@ import lol.gito.radgyms.common.api.enumeration.GuiScreenCloseChoice
 import lol.gito.radgyms.common.api.event.GymEvents
 import lol.gito.radgyms.common.api.event.GymEvents.ENTER_SCREEN_CLOSE
 import lol.gito.radgyms.common.client.render.gui.widget.LevelSliderWidget
+import lol.gito.radgyms.common.defaultElementalTypes
 import lol.gito.radgyms.common.extension.math.Vec2i
 import lol.gito.radgyms.common.helper.ElementalTypeTranslationHelper.buildTypeText
 import lol.gito.radgyms.common.helper.tl
@@ -36,7 +36,7 @@ class GymEnterScreen(
     val usesLeft: Int? = null,
 ) : AbstractGymScreen(
     when (type) {
-        null, "chaos", in (ElementalTypes.all().map { it.showdownId }) -> tl(
+        null, "chaos", in defaultElementalTypes -> tl(
             modId("gui.common.set-gym-level"),
             buildTypeText(type),
         )

--- a/common/src/main/kotlin/lol/gito/radgyms/common/command/argument/ElementalTypeArgumentType.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/command/argument/ElementalTypeArgumentType.kt
@@ -15,6 +15,7 @@ import com.mojang.brigadier.context.CommandContext
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
 import com.mojang.brigadier.suggestion.Suggestions
 import com.mojang.brigadier.suggestion.SuggestionsBuilder
+import lol.gito.radgyms.common.RadGyms.modId
 import lol.gito.radgyms.common.defaultElementalTypes
 import lol.gito.radgyms.common.helper.tl
 import net.minecraft.commands.SharedSuggestionProvider

--- a/common/src/main/kotlin/lol/gito/radgyms/common/command/argument/ElementalTypeArgumentType.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/command/argument/ElementalTypeArgumentType.kt
@@ -15,6 +15,7 @@ import com.mojang.brigadier.context.CommandContext
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
 import com.mojang.brigadier.suggestion.Suggestions
 import com.mojang.brigadier.suggestion.SuggestionsBuilder
+import lol.gito.radgyms.common.defaultElementalTypes
 import lol.gito.radgyms.common.helper.tl
 import net.minecraft.commands.SharedSuggestionProvider
 import java.util.concurrent.CompletableFuture
@@ -31,7 +32,7 @@ class ElementalTypeArgumentType : ArgumentType<ElementalType> {
         context: CommandContext<S>,
         builder: SuggestionsBuilder,
     ): CompletableFuture<Suggestions> = SharedSuggestionProvider.suggest(
-        ElementalTypes.all().map { it.showdownId },
+        defaultElementalTypes,
         builder,
     )
 

--- a/common/src/main/kotlin/lol/gito/radgyms/common/gym/team/FixedTeamGenerator.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/gym/team/FixedTeamGenerator.kt
@@ -23,7 +23,7 @@ object FixedTeamGenerator : GenericTeamGenerator() {
         GENERATE_TEAM.post(
             GymEvents.GenerateTeamEvent(
                 player,
-                possibleTypes(rawTeam).toList(),
+                listOf(),
                 level,
                 trainer.id,
                 trainer.leader,

--- a/common/src/main/kotlin/lol/gito/radgyms/common/gym/team/GenericTeamGenerator.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/gym/team/GenericTeamGenerator.kt
@@ -20,6 +20,7 @@ import lol.gito.radgyms.common.api.enumeration.GymBattleFormat
 import lol.gito.radgyms.common.api.event.GymEvents
 import lol.gito.radgyms.common.api.event.GymEvents.GENERATE_TEAM
 import lol.gito.radgyms.common.api.team.TeamGeneratorInterface
+import lol.gito.radgyms.common.defaultElementalTypes
 import lol.gito.radgyms.common.registry.RadGymsSpeciesRegistry.speciesByType
 import net.minecraft.server.level.ServerPlayer
 import kotlin.random.Random
@@ -60,7 +61,7 @@ abstract class GenericTeamGenerator : TeamGeneratorInterface {
 
         val event = GymEvents.GenerateTeamEvent(
             player,
-            types ?: ElementalTypes.all().shuffled().take(1),
+            types ?: defaultElementalTypes.shuffled().take(1).map { ElementalTypes.getOrException(it) },
             level,
             trainer.id,
             trainer.leader,

--- a/common/src/main/kotlin/lol/gito/radgyms/common/gym/team/PoolTeamGenerator.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/gym/team/PoolTeamGenerator.kt
@@ -40,7 +40,7 @@ object PoolTeamGenerator : GenericTeamGenerator() {
         GENERATE_TEAM.post(
             GymEvents.GenerateTeamEvent(
                 player,
-                possibleTypes(rawTeam).toList(),
+                listOf(),
                 level,
                 trainer.id,
                 trainer.leader,

--- a/common/src/main/kotlin/lol/gito/radgyms/common/item/PokeCache.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/item/PokeCache.kt
@@ -8,7 +8,6 @@
 package lol.gito.radgyms.common.item
 
 import com.cobblemon.mod.common.Cobblemon
-import com.cobblemon.mod.common.api.types.ElementalTypes
 import com.cobblemon.mod.common.item.CobblemonItem
 import com.cobblemon.mod.common.pokemon.Pokemon
 import lol.gito.radgyms.common.RadGyms.config
@@ -16,6 +15,7 @@ import lol.gito.radgyms.common.RadGyms.modId
 import lol.gito.radgyms.common.api.event.GymEvents
 import lol.gito.radgyms.common.api.event.GymEvents.CACHE_ROLL_POKE
 import lol.gito.radgyms.common.cache.CacheHandler
+import lol.gito.radgyms.common.defaultElementalTypes
 import lol.gito.radgyms.common.helper.ElementalTypeTranslationHelper.buildPrefixedSuffixedTypeText
 import lol.gito.radgyms.common.helper.tl
 import lol.gito.radgyms.common.registry.RadGymsDataComponents.RG_CACHE_SHINY_BOOST_COMPONENT
@@ -48,11 +48,10 @@ open class PokeCache(private val rarity: Rarity) : CobblemonItem(Properties().ra
             val stack = user.getItemInHand(hand)
             val rarity = stack.getOrDefault(RARITY, Rarity.COMMON)
             val boost = calculateCacheBoost(stack, user.offhandItem, user)
-            val type =
-                when (stack.getOrDefault(RG_GYM_TYPE_COMPONENT, ElementalTypes.all().random().showdownId)) {
-                    "chaos" -> ElementalTypes.all().random().showdownId
-                    else -> stack.getOrDefault(RG_GYM_TYPE_COMPONENT, ElementalTypes.all().random().showdownId)
-                }
+            val type = when (stack.getOrDefault(RG_GYM_TYPE_COMPONENT, defaultElementalTypes.random())) {
+                "chaos" -> defaultElementalTypes.random()
+                else -> stack.getOrDefault(RG_GYM_TYPE_COMPONENT, defaultElementalTypes.random())
+            }
             val poke: Pokemon = CacheHandler.getPoke(type, rarity, user as ServerPlayer, boost)
             CACHE_ROLL_POKE.emit(GymEvents.CacheRollPokeEvent(user, poke, type, rarity, boost))
 

--- a/common/src/main/kotlin/lol/gito/radgyms/common/net/server/handler/GymEnterC2SHandler.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/net/server/handler/GymEnterC2SHandler.kt
@@ -8,9 +8,9 @@
 package lol.gito.radgyms.common.net.server.handler
 
 import com.cobblemon.mod.common.api.net.ServerNetworkPacketHandler
-import com.cobblemon.mod.common.api.types.ElementalTypes
 import lol.gito.radgyms.common.RadGyms
 import lol.gito.radgyms.common.block.entity.GymEntranceEntity
+import lol.gito.radgyms.common.defaultElementalTypes
 import lol.gito.radgyms.common.extension.displayClientMessage
 import lol.gito.radgyms.common.helper.ElementalTypeTranslationHelper
 import lol.gito.radgyms.common.helper.tl
@@ -26,20 +26,18 @@ object GymEnterC2SHandler : ServerNetworkPacketHandler<GymEnterC2S> {
         RadGyms.debug("Using key? : ${packet.key}")
         var message = tl("message.info.gym_init", ElementalTypeTranslationHelper.buildTypeText(packet.type))
 
-        val type: String =
-            when (packet.type) {
-                "chaos", null -> ElementalTypes.all().random().showdownId
-                else -> packet.type
-            }
+        val type: String = when (packet.type) {
+            "chaos", null -> defaultElementalTypes.random()
+            else -> packet.type
+        }
 
         if (packet.key) {
             val stack = player.mainHandItem
 
             if (stack.item == RadGymsItems.GYM_KEY) {
-                val stackType =
-                    stack.components
-                        .getOrDefault(RadGymsDataComponents.RG_GYM_TYPE_COMPONENT, "chaos")
-                        .let { it ?: packet.type }
+                val stackType = stack.components
+                    .getOrDefault(RadGymsDataComponents.RG_GYM_TYPE_COMPONENT, "chaos")
+                    .let { it ?: packet.type }
                 RadGyms.debug("Gym key type : $stackType")
 
                 message = tl("message.info.gym_init", ElementalTypeTranslationHelper.buildTypeText(stackType))


### PR DESCRIPTION
## Description

- Reuse `defaultElementalTypes` list instead of possible modified cobblemon elemental types list to prevent clashes with custom types that might be added by others
- Add missing fairy type to it

## Type of Change (Put `X` in applicable square)

- [x] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Documentation

## Checklist (Put `X` in applicable square)

- [ ] Assembled mod jars work in production environment