### PR TITLE
feat: add ability to define poke cache boosters

### DIFF
--- a/common/src/main/kotlin/lol/gito/radgyms/common/RadGyms.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/RadGyms.kt
@@ -24,7 +24,9 @@ import lol.gito.radgyms.common.net.server.payload.ServerSettingsS2C
 import lol.gito.radgyms.common.registry.RadGymsSpeciesRegistry
 import lol.gito.radgyms.common.registry.RadGymsStats
 import net.minecraft.commands.synchronization.SingletonArgumentInfo
+import net.minecraft.core.Holder
 import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.item.Item
 import net.minecraft.world.level.border.WorldBorder
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -43,13 +45,16 @@ object RadGyms {
     @JvmField
     val dimensionWorldBorder: WorldBorder = WorldBorder()
 
+    @JvmField
     val statistics: RadGymsStats = RadGymsStats
 
+    @JvmField
     val dataProvider: DataProvider = RadGymsDataProvider
 
     lateinit var config: RadGymsConfig
     lateinit var implementation: RadGymsImplementation
     lateinit var gymInitializer: GymInitializer
+    lateinit var cacheBoosters: Map<Holder.Reference<Item>, Int>
 
     fun preInitialize(implementation: RadGymsImplementation) {
         this.implementation = implementation
@@ -94,7 +99,11 @@ object RadGyms {
 
         if (configFile.exists()) {
             LOGGER.info("Loading config")
-            config = with(configFile.inputStream()) { Json.decodeFromStream<RadGymsConfig>(this) }
+            config = with(configFile.inputStream()) {
+                val fileData = Json.decodeFromStream<RadGymsConfig>(this)
+
+                return@with RadGymsConfig.DEFAULT.combine(fileData)
+            }
         } else {
             LOGGER.info("No config found, creating new")
             config = RadGymsConfig.DEFAULT
@@ -105,7 +114,6 @@ object RadGyms {
             ServerSettingsS2C(
                 config.maxEntranceUses!!,
                 config.shardRewards!!,
-                config.lapisBoostAmount!!,
                 config.ignoredSpecies!!,
                 config.minLevel!!,
                 config.maxLevel!!,

--- a/common/src/main/kotlin/lol/gito/radgyms/common/api/serialization/KResourceLocationSerializer.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/api/serialization/KResourceLocationSerializer.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026. gitoido-mc
+ * This Source Code Form is subject to the terms of the GNU General Public License v3.0.
+ * If a copy of the GNU General Public License v3.0 was not distributed with this file,
+ * you can obtain one at https://github.com/gitoido-mc/rad-gyms/blob/main/LICENSE.
+ */
+
+package lol.gito.radgyms.common.api.serialization
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import net.minecraft.resources.ResourceLocation
+
+object KResourceLocationSerializer : KSerializer<ResourceLocation> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
+        "net.minecraft.resources.ResourceLocation",
+        PrimitiveKind.STRING,
+    )
+
+    override fun serialize(encoder: Encoder, value: ResourceLocation) = encoder.encodeString(value.toString())
+
+    override fun deserialize(decoder: Decoder): ResourceLocation = ResourceLocation.parse(decoder.decodeString())
+}

--- a/common/src/main/kotlin/lol/gito/radgyms/common/config/RadGymsConfig.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/config/RadGymsConfig.kt
@@ -10,22 +10,27 @@ package lol.gito.radgyms.common.config
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import lol.gito.radgyms.common.api.serialization.KResourceLocationSerializer
+import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.item.Rarity
 
 @Serializable
 data class RadGymsConfig(
     @SerialName("__version")
-    val version: String = "0.4.0",
+    val version: String = "0.4.5",
     val debug: Boolean? = null,
-    val maxEntranceUses: Int? = null,
-    val shardRewards: Boolean? = null,
-    val lapisBoostAmount: Int? = null,
-    val ignoredSpecies: List<String>? = null,
-    val ignoredForms: List<String>? = null,
+    val deriveAverageGymLevel: Boolean? = null,
     val minLevel: Int? = null,
     val maxLevel: Int? = null,
-    val deriveAverageGymLevel: Boolean? = null,
+    val maxEntranceUses: Int? = null,
+    val shardRewards: Boolean? = null,
+    val ignoredSpecies: List<String>? = null,
     val pokeCachePools: Map<String, Set<String>>? = null,
+    val pokeCacheBoosters: Map<
+        @Serializable(KResourceLocationSerializer::class)
+        ResourceLocation,
+        Int,
+        >? = null,
 ) {
     companion object {
         @Transient
@@ -39,8 +44,6 @@ data class RadGymsConfig(
             maxLevel = 100,
             // Gym entrance max uses per player
             maxEntranceUses = 3,
-            // Cache shiny boost amount per unit of lapis
-            lapisBoostAmount = 1,
             // Add shard rewards
             shardRewards = true,
             // Ignored species
@@ -67,6 +70,10 @@ data class RadGymsConfig(
                     Rarity.RARE.serializedName,
                 ),
             ),
+            pokeCacheBoosters = mutableMapOf(
+                ResourceLocation.parse("minecraft:lapis_lazuli") to 1,
+                ResourceLocation.parse("minecraft:lapis_lazuli_block") to 9,
+            ),
         )
     }
 
@@ -74,11 +81,11 @@ data class RadGymsConfig(
         debug = other.debug ?: debug,
         maxEntranceUses = other.maxEntranceUses ?: maxEntranceUses,
         shardRewards = other.shardRewards ?: shardRewards,
-        lapisBoostAmount = other.lapisBoostAmount ?: lapisBoostAmount,
         ignoredSpecies = other.ignoredSpecies ?: ignoredSpecies,
         minLevel = other.minLevel ?: minLevel,
         maxLevel = other.maxLevel ?: maxLevel,
         deriveAverageGymLevel = other.deriveAverageGymLevel ?: deriveAverageGymLevel,
         pokeCachePools = other.pokeCachePools ?: pokeCachePools,
+        pokeCacheBoosters = other.pokeCacheBoosters ?: pokeCacheBoosters,
     )
 }

--- a/common/src/main/kotlin/lol/gito/radgyms/common/event/EventManager.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/event/EventManager.kt
@@ -57,6 +57,7 @@ import lol.gito.radgyms.common.registry.RadGymsSpeciesRegistry.speciesOfType
 import lol.gito.radgyms.common.registry.RadGymsTemplates
 import lol.gito.radgyms.common.world.StructurePlacer
 import lol.gito.radgyms.common.world.state.RadGymsState
+import net.minecraft.core.registries.BuiltInRegistries
 
 @Suppress("TooManyFunctions")
 object EventManager {
@@ -64,6 +65,7 @@ object EventManager {
         debug("Registering event handlers")
         // Minecraft events
         PlatformEvents.SERVER_STARTING.subscribe(Priority.NORMAL, ::onServerStarting)
+        PlatformEvents.SERVER_STARTED.subscribe(Priority.NORMAL, ::onServerStarted)
         PlatformEvents.SERVER_PLAYER_LOGIN.subscribe(Priority.NORMAL, ::onPlayerJoin)
         PlatformEvents.SERVER_PLAYER_LOGOUT.subscribe(Priority.HIGHEST, ::onPlayerDisconnect)
         PlatformEvents.RIGHT_CLICK_BLOCK.subscribe(Priority.NORMAL, ::onBlockInteract)
@@ -133,12 +135,22 @@ object EventManager {
         trainerRegistry.init(event.server)
     }
 
+    @Suppress("UNUSED_PARAMETER")
+    private fun onServerStarted(event: ServerEvent.Started) {
+        RadGyms.cacheBoosters = try {
+            config.pokeCacheBoosters?.mapKeys { entry ->
+                BuiltInRegistries.ITEM.getHolder(entry.key).get()
+            } ?: emptyMap()
+        } catch (_: Throwable) {
+            emptyMap()
+        }
+    }
+
     private fun onPlayerJoin(event: ServerPlayerEvent) {
         debug("Sending server settings to player ${event.player.name}")
         ServerSettingsS2C(
             config.maxEntranceUses!!,
             config.shardRewards!!,
-            config.lapisBoostAmount!!,
             config.ignoredSpecies!!,
             config.minLevel!!,
             config.maxLevel!!,

--- a/common/src/main/kotlin/lol/gito/radgyms/common/item/PokeCache.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/item/PokeCache.kt
@@ -10,7 +10,7 @@ package lol.gito.radgyms.common.item
 import com.cobblemon.mod.common.Cobblemon
 import com.cobblemon.mod.common.item.CobblemonItem
 import com.cobblemon.mod.common.pokemon.Pokemon
-import lol.gito.radgyms.common.RadGyms.config
+import lol.gito.radgyms.common.RadGyms.cacheBoosters
 import lol.gito.radgyms.common.RadGyms.modId
 import lol.gito.radgyms.common.api.event.GymEvents
 import lol.gito.radgyms.common.api.event.GymEvents.CACHE_ROLL_POKE
@@ -36,8 +36,6 @@ import net.minecraft.world.item.Items.LAPIS_LAZULI
 import net.minecraft.world.item.Rarity
 import net.minecraft.world.item.TooltipFlag
 import net.minecraft.world.level.Level
-
-const val RG_CACHE_BLOCK_BOOST = 9
 
 open class PokeCache(private val rarity: Rarity) : CobblemonItem(Properties().rarity(rarity)) {
     override fun use(level: Level, user: Player, hand: InteractionHand): InteractionResultHolder<ItemStack> = when {
@@ -90,21 +88,12 @@ open class PokeCache(private val rarity: Rarity) : CobblemonItem(Properties().ra
     private fun calculateCacheBoost(stack: ItemStack, offhand: ItemStack, user: Player): Int =
         with(stack.getOrDefault(RG_CACHE_SHINY_BOOST_COMPONENT, 0)) {
             if (equals(Cobblemon.config.shinyRate)) return@with this
-
-            return@with when (offhand.item) {
-                LAPIS_LAZULI -> this.plus(config.lapisBoostAmount!!).also {
+            return@with when (val boost = cacheBoosters.getOrDefault(offhand.itemHolder, null)) {
+                null -> this
+                else -> this.plus(boost).also {
                     stack.set(RG_CACHE_SHINY_BOOST_COMPONENT, it)
                     offhand.consume(1, user)
                 }
-
-                LAPIS_BLOCK -> this.plus(RG_CACHE_BLOCK_BOOST * config.lapisBoostAmount!!)
-                    .coerceAtMost(Cobblemon.config.shinyRate.toInt().dec())
-                    .also {
-                        stack.set(RG_CACHE_SHINY_BOOST_COMPONENT, it)
-                        offhand.consume(1, user)
-                    }
-
-                else -> this
             }
         }
 }

--- a/common/src/main/kotlin/lol/gito/radgyms/common/net/server/payload/ServerSettingsS2C.kt
+++ b/common/src/main/kotlin/lol/gito/radgyms/common/net/server/payload/ServerSettingsS2C.kt
@@ -16,7 +16,6 @@ import net.minecraft.resources.ResourceLocation
 class ServerSettingsS2C(
     val maxEntranceUses: Int,
     val shardRewards: Boolean,
-    val lapisBoostAmount: Int,
     val ignoredSpecies: List<String>,
     val minLevel: Int,
     val maxLevel: Int,
@@ -29,7 +28,6 @@ class ServerSettingsS2C(
         fun decode(buffer: RegistryFriendlyByteBuf) = ServerSettingsS2C(
             ByteBufCodecs.INT.decode(buffer),
             ByteBufCodecs.BOOL.decode(buffer),
-            ByteBufCodecs.INT.decode(buffer),
             ByteBufCodecs.STRING_UTF8.apply(ByteBufCodecs.list()).decode(buffer),
             ByteBufCodecs.INT.decode(buffer),
             ByteBufCodecs.INT.decode(buffer),
@@ -39,7 +37,6 @@ class ServerSettingsS2C(
     override fun encode(buffer: RegistryFriendlyByteBuf) {
         ByteBufCodecs.INT.encode(buffer, maxEntranceUses)
         ByteBufCodecs.BOOL.encode(buffer, shardRewards)
-        ByteBufCodecs.INT.encode(buffer, lapisBoostAmount)
         ByteBufCodecs.STRING_UTF8.apply(ByteBufCodecs.list()).encode(buffer, ignoredSpecies)
         ByteBufCodecs.INT.encode(buffer, minLevel)
         ByteBufCodecs.INT.encode(buffer, maxLevel)


### PR DESCRIPTION
## Description
Add config option for custom cache boost items
Refactor `PokeCache::use` function to look into this config option

Closes #129 

## Type of Change (Put `X` in applicable square)
- [ ] Bugfix
- [X] Feature
- [X] Refactoring
- [ ] Documentation

## Checklist (Put `X` in applicable square)
- [ ] Assembled mod jars work in production environment
